### PR TITLE
Using alpine 3.9 docker image since the alpine:latest does not work

### DIFF
--- a/phoenix_backend/Dockerfile
+++ b/phoenix_backend/Dockerfile
@@ -6,7 +6,7 @@ COPY . /app
 RUN mix deps.get
 RUN MIX_ENV=prod mix release --no-tar
 
-FROM alpine:latest
+FROM alpine:3.9
 RUN apk add bash openssl
 WORKDIR /app
 COPY --from=builder /app/_build/prod/rel/phoenix_backend/ .

--- a/plug_gateway/Dockerfile
+++ b/plug_gateway/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add git
 RUN mix deps.get
 RUN MIX_ENV=prod mix release --no-tar
 
-FROM alpine:latest
+FROM alpine:3.9
 RUN apk add bash openssl
 WORKDIR /app
 COPY --from=builder /app/_build/prod/rel/plug_gateway/ .


### PR DESCRIPTION
I was observing the two elixir docker containers failing to start because they were trying to be run on a newer version of alpine linux than what they were built with.

To test (on the master branch):
```
docker-compose build
docker-compose up
```
and observe this error from the backend and plug_gateway containers.

```
backend_1     | dlsym: Resource temporarily unavailable
backend_1     | Unusable Erlang runtime system! This is likely due to being compiled for another system than the host is running
```

Then switch to this branch.
```
docker-compose build
docker-compose up
```
observe the backend and plug_gateway startup and run like you would expect.


Since this is an example, it should be pretty future proof and pointing at the latest alpine image to run on isn't ideal since we're already hardcoded on a specific alpine image to build with. 

Additionally to check the version of alpine linux that the elixir build image is using you can do this:
```
~/dev/spandex_example $ docker run -it elixir:1.7-alpine /bin/sh
/ # cat /etc/*release*
3.9.5
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.9.5
PRETTY_NAME="Alpine Linux v3.9"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```
notice: **`VERSION_ID=3.9.5`**